### PR TITLE
Day5_ 일부 몬스터 로직 수정 및 몬스터 사운드 추가

### DIFF
--- a/Assets/Dev/KST_DF/Animation/MonsterAC.controller.meta
+++ b/Assets/Dev/KST_DF/Animation/MonsterAC.controller.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: ecedf3d70aa0d4a56ad93808aac47408
+guid: f3356aafe49cc934e9e7503ebf532c35
 NativeFormatImporter:
   externalObjects: {}
-  mainObjectFileID: 9100000
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Dev/KST_DF/Prefabs/Character/Etc.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Etc.prefab
@@ -794,6 +794,7 @@ GameObject:
   - component: {fileID: 1557029877192380602}
   - component: {fileID: 1586915278615191679}
   - component: {fileID: 8529695729228882531}
+  - component: {fileID: -3773709878701110892}
   m_Layer: 15
   m_Name: Etc
   m_TagString: Untagged
@@ -843,7 +844,7 @@ Animator:
   m_GameObject: {fileID: 944514543498036531}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: b69174d668ba02d44b14a084b217670a, type: 3}
-  m_Controller: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
+  m_Controller: {fileID: 9100000, guid: f3356aafe49cc934e9e7503ebf532c35, type: 2}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -961,6 +962,22 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 0.5
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &-3773709878701110892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944514543498036531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ef31caf2046364285cd21114743285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shotSound: {fileID: 8300000, guid: 727597d5f3999491ea0ee5ecec8f64b1, type: 3}
+  hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
 --- !u!1 &1021614894529511336
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/KST_DF/Prefabs/Character/Goblin.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Goblin.prefab
@@ -1626,7 +1626,7 @@ GameObject:
   - component: {fileID: 896150774526458834}
   - component: {fileID: 3100148086976602383}
   - component: {fileID: 8207372480859528588}
-  m_Layer: 6
+  m_Layer: 15
   m_Name: Goblin
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Dev/KST_DF/Prefabs/Character/Goblin.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Goblin.prefab
@@ -1626,6 +1626,7 @@ GameObject:
   - component: {fileID: 896150774526458834}
   - component: {fileID: 3100148086976602383}
   - component: {fileID: 8207372480859528588}
+  - component: {fileID: 7037682552368852359}
   m_Layer: 15
   m_Name: Goblin
   m_TagString: Untagged
@@ -1675,7 +1676,7 @@ Animator:
   m_GameObject: {fileID: 3161129422670007100}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: b69174d668ba02d44b14a084b217670a, type: 3}
-  m_Controller: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
+  m_Controller: {fileID: 9100000, guid: f3356aafe49cc934e9e7503ebf532c35, type: 2}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -1793,6 +1794,22 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 0.5
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &7037682552368852359
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3161129422670007100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ef31caf2046364285cd21114743285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shotSound: {fileID: 8300000, guid: 727597d5f3999491ea0ee5ecec8f64b1, type: 3}
+  hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
 --- !u!1 &3463827974993997852
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/KST_DF/Prefabs/Character/Goblin1.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Goblin1.prefab
@@ -794,6 +794,7 @@ GameObject:
   - component: {fileID: 1557029877192380602}
   - component: {fileID: 1586915278615191679}
   - component: {fileID: 8529695729228882531}
+  - component: {fileID: 1239694486584849967}
   m_Layer: 15
   m_Name: Goblin1
   m_TagString: Untagged
@@ -843,7 +844,7 @@ Animator:
   m_GameObject: {fileID: 944514543498036531}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: b69174d668ba02d44b14a084b217670a, type: 3}
-  m_Controller: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
+  m_Controller: {fileID: 9100000, guid: f3356aafe49cc934e9e7503ebf532c35, type: 2}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -961,6 +962,22 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 1
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &1239694486584849967
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944514543498036531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ef31caf2046364285cd21114743285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shotSound: {fileID: 8300000, guid: 727597d5f3999491ea0ee5ecec8f64b1, type: 3}
+  hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
 --- !u!1 &1021614894529511336
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/KST_DF/Prefabs/Character/Goblin2.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Goblin2.prefab
@@ -825,6 +825,7 @@ GameObject:
   - component: {fileID: 1557029877192380602}
   - component: {fileID: 1586915278615191679}
   - component: {fileID: 8529695729228882531}
+  - component: {fileID: -3341361963543210022}
   m_Layer: 15
   m_Name: Goblin2
   m_TagString: Untagged
@@ -874,7 +875,7 @@ Animator:
   m_GameObject: {fileID: 944514543498036531}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: b69174d668ba02d44b14a084b217670a, type: 3}
-  m_Controller: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
+  m_Controller: {fileID: 9100000, guid: f3356aafe49cc934e9e7503ebf532c35, type: 2}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -992,6 +993,22 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 1
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &-3341361963543210022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944514543498036531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ef31caf2046364285cd21114743285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shotSound: {fileID: 8300000, guid: 727597d5f3999491ea0ee5ecec8f64b1, type: 3}
+  hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
 --- !u!1 &1021614894529511336
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/KST_DF/Prefabs/Character/RockGolem.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/RockGolem.prefab
@@ -3637,7 +3637,7 @@ GameObject:
   - component: {fileID: 7645178602707883054}
   - component: {fileID: 4071697431531923538}
   - component: {fileID: 2046319266326444097}
-  m_Layer: 0
+  m_Layer: 17
   m_Name: RockGolem
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Dev/KST_DF/Prefabs/Character/RockGolem.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/RockGolem.prefab
@@ -3637,6 +3637,7 @@ GameObject:
   - component: {fileID: 7645178602707883054}
   - component: {fileID: 4071697431531923538}
   - component: {fileID: 2046319266326444097}
+  - component: {fileID: 4317351206859812431}
   m_Layer: 17
   m_Name: RockGolem
   m_TagString: Untagged
@@ -3686,7 +3687,7 @@ Animator:
   m_GameObject: {fileID: 7745300230697871013}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: b69174d668ba02d44b14a084b217670a, type: 3}
-  m_Controller: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
+  m_Controller: {fileID: 9100000, guid: f3356aafe49cc934e9e7503ebf532c35, type: 2}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -3805,6 +3806,22 @@ CapsuleCollider:
   m_Height: 1.728935
   m_Direction: 1
   m_Center: {x: 0, y: 0.93304, z: -0.057038546}
+--- !u!114 &4317351206859812431
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7745300230697871013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ef31caf2046364285cd21114743285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shotSound: {fileID: 8300000, guid: 727597d5f3999491ea0ee5ecec8f64b1, type: 3}
+  hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
 --- !u!1 &7748486353921059994
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/KST_DF/Prefabs/Character/Skeleton.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Skeleton.prefab
@@ -3610,6 +3610,7 @@ GameObject:
   - component: {fileID: 2876877853764780653}
   - component: {fileID: 6376506400435113031}
   - component: {fileID: 4257959634729531231}
+  - component: {fileID: -2672020249473684764}
   m_Layer: 15
   m_Name: Skeleton
   m_TagString: Untagged
@@ -3659,7 +3660,7 @@ Animator:
   m_GameObject: {fileID: 7425997435929176841}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: b69174d668ba02d44b14a084b217670a, type: 3}
-  m_Controller: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
+  m_Controller: {fileID: 9100000, guid: f3356aafe49cc934e9e7503ebf532c35, type: 2}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -3777,6 +3778,22 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 0.5
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &-2672020249473684764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7425997435929176841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ef31caf2046364285cd21114743285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shotSound: {fileID: 8300000, guid: 727597d5f3999491ea0ee5ecec8f64b1, type: 3}
+  hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
 --- !u!1 &7452166841410569182
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/KST_DF/Prefabs/Character/Skeleton.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Skeleton.prefab
@@ -3610,7 +3610,7 @@ GameObject:
   - component: {fileID: 2876877853764780653}
   - component: {fileID: 6376506400435113031}
   - component: {fileID: 4257959634729531231}
-  m_Layer: 0
+  m_Layer: 15
   m_Name: Skeleton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3684,10 +3684,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_hp: 10
   m_maxHp: 10
+  attackType: 0
   m_attackDamage: 2
   m_collsionDamage: 1
   m_attackCooldown: 1
   m_canAttack: 1
+  m_isAttacking: 0
   m_isPlayerInAttackArea: 0
   m_sphereCollider: {fileID: 4257959634729531231}
   m_attackRange: 2
@@ -3695,8 +3697,11 @@ MonoBehaviour:
   m_moveSpeed: 3
   monsterType: 1
   m_isMonsterDie: 0
-  speed: 0
+  m_speed: 0
   isPool: 1
+  m_arrowPool: {fileID: 0}
+  m_arrowShootingTransform: {fileID: 0}
+  m_arrowSpeed: 10
   m_playerPos: {fileID: 0}
   m_canTrackingPlayer: 1
   playerHp: {fileID: 0}

--- a/Assets/Dev/KST_DF/Prefabs/Character/Skeleton1.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Skeleton1.prefab
@@ -794,6 +794,7 @@ GameObject:
   - component: {fileID: 1557029877192380602}
   - component: {fileID: 1586915278615191679}
   - component: {fileID: 8529695729228882531}
+  - component: {fileID: 2072439064204589321}
   m_Layer: 15
   m_Name: Skeleton1
   m_TagString: Untagged
@@ -843,7 +844,7 @@ Animator:
   m_GameObject: {fileID: 944514543498036531}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: b69174d668ba02d44b14a084b217670a, type: 3}
-  m_Controller: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
+  m_Controller: {fileID: 9100000, guid: f3356aafe49cc934e9e7503ebf532c35, type: 2}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -961,6 +962,22 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 1
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &2072439064204589321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944514543498036531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ef31caf2046364285cd21114743285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shotSound: {fileID: 8300000, guid: 727597d5f3999491ea0ee5ecec8f64b1, type: 3}
+  hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
 --- !u!1 &1021614894529511336
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/KST_DF/Prefabs/Character/Skeleton2.prefab
+++ b/Assets/Dev/KST_DF/Prefabs/Character/Skeleton2.prefab
@@ -825,6 +825,7 @@ GameObject:
   - component: {fileID: 1557029877192380602}
   - component: {fileID: 1586915278615191679}
   - component: {fileID: 8529695729228882531}
+  - component: {fileID: -5549480053609708554}
   m_Layer: 15
   m_Name: Skeleton2
   m_TagString: Untagged
@@ -874,7 +875,7 @@ Animator:
   m_GameObject: {fileID: 944514543498036531}
   m_Enabled: 1
   m_Avatar: {fileID: 9000000, guid: b69174d668ba02d44b14a084b217670a, type: 3}
-  m_Controller: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
+  m_Controller: {fileID: 9100000, guid: f3356aafe49cc934e9e7503ebf532c35, type: 2}
   m_CullingMode: 1
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -992,6 +993,22 @@ SphereCollider:
   serializedVersion: 3
   m_Radius: 1
   m_Center: {x: 0, y: 1, z: 0}
+--- !u!114 &-5549480053609708554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944514543498036531}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2ef31caf2046364285cd21114743285, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shotSound: {fileID: 8300000, guid: 727597d5f3999491ea0ee5ecec8f64b1, type: 3}
+  hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
 --- !u!1 &1021614894529511336
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Dev/KST_DF/Scene/AnimationTest.unity
+++ b/Assets/Dev/KST_DF/Scene/AnimationTest.unity
@@ -122,67 +122,59 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &68540393
-PrefabInstance:
+--- !u!1 &209957849
+GameObject:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 209957851}
+  - component: {fileID: 209957850}
+  m_Layer: 0
+  m_Name: MonsterPool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &209957850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 209957849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9d689b583697e427aa7897798f3e5909, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_prefabs:
+  - {fileID: 3161129422670007100, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
+  - {fileID: 944514543498036531, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
+  - {fileID: 944514543498036531, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
+  - {fileID: 7425997435929176841, guid: cd74fac6dc2cc495c802f7b794d820d4, type: 3}
+  - {fileID: 944514543498036531, guid: df84c7438ee37b34c8c4cca871663eb4, type: 3}
+  - {fileID: 944514543498036531, guid: 587b090e483c9cf4f9fc2de35d2781c2, type: 3}
+  - {fileID: 944514543498036531, guid: f27e48f6327094753b4bfe2b5bd8dbf4, type: 3}
+  m_poolSize: 1
+--- !u!4 &209957851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 209957849}
   serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 944514543498036531, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_Name
-      value: Etc 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3105365765575557917, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_arrowPool
-      value: 
-      objectReference: {fileID: 2112279422}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -1.72
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.0000009536743
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1.3575964
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f2295973e2c941142ac8a151e5052f9d, type: 3}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.061784, y: 13.091, z: 12.151227}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &244378046
 GameObject:
   m_ObjectHideFlags: 0
@@ -199,7 +191,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &244378047
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -214,7 +206,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_playerPos: {fileID: 923908112}
   m_spawnTime: 1
-  m_patternTime: 1000
+  m_patternTime: 3
   m_straightMonsterPrefabs:
   - {fileID: 7745300230697871013, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
   m_spawnRange: 12.35
@@ -476,71 +468,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 244378048}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &804329149
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.54
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4319596984881763283, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6729763948017804256, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: ecedf3d70aa0d4a56ad93808aac47408, type: 2}
-    - target: {fileID: 7745300230697871013, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_Name
-      value: RockGolem
-      objectReference: {fileID: 0}
-    - target: {fileID: 7745300230697871013, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5ef42956b4e45400abb2633c2fb1ee61, type: 3}
 --- !u!1 &859922694
 GameObject:
   m_ObjectHideFlags: 0
@@ -795,6 +722,8 @@ MonoBehaviour:
   CurrentHealth: 5
   MaxHealth: 5
   LimitMaxHealth: 10
+  isDead: 0
+  isHit: 0
 --- !u!1 &1004610391
 GameObject:
   m_ObjectHideFlags: 0
@@ -856,177 +785,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 244378048}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1026508870
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3161129422670007100, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_Name
-      value: Goblin
-      objectReference: {fileID: 0}
-    - target: {fileID: 3161129422670007100, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.1629992
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.00000011920929
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 4.661421
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757801005614552113, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
---- !u!1001 &1069556262
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 944514543498036531, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_Name
-      value: Etc 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 944514543498036531, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 9.13
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.0000009536743
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1.3575964
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6848081486657131623, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 47f88388742bd674a857c6ac6b6f1569, type: 3}
---- !u!1 &1138217494
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1138217496}
-  - component: {fileID: 1138217495}
-  m_Layer: 0
-  m_Name: MonsterPool
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1138217495
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1138217494}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9d689b583697e427aa7897798f3e5909, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_prefabs:
-  - {fileID: 3161129422670007100, guid: 0bb623b00041d40adb1d4900c8c78996, type: 3}
-  - {fileID: 7425997435929176841, guid: cd74fac6dc2cc495c802f7b794d820d4, type: 3}
-  - {fileID: 944514543498036531, guid: f27e48f6327094753b4bfe2b5bd8dbf4, type: 3}
-  m_poolSize: 1
---- !u!4 &1138217496
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1138217494}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4.061784, y: 13.091, z: 12.151227}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1182201600
 GameObject:
@@ -1151,67 +909,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1489228595
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 128030, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_Name
-      value: SM_Wep_Goblin_Staff_01
-      objectReference: {fileID: 0}
-    - target: {fileID: 128030, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.071
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.907
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 462362, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3e567880dba875d4fbc7834ca7f5b289, type: 3}
 --- !u!1 &1627171127
 GameObject:
   m_ObjectHideFlags: 0
@@ -1538,82 +1235,15 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &2136879624
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 174694, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_Name
-      value: SM_Wep_Staff_Gem_01
-      objectReference: {fileID: 0}
-    - target: {fileID: 174694, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.616
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 414092, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b43bfa1513653534694fade06a14b8b2, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1289124599}
   - {fileID: 1790247279}
-  - {fileID: 804329149}
-  - {fileID: 1026508870}
   - {fileID: 923908112}
   - {fileID: 724560773}
   - {fileID: 859922698}
   - {fileID: 244378048}
-  - {fileID: 1138217496}
-  - {fileID: 1069556262}
-  - {fileID: 1489228595}
-  - {fileID: 2136879624}
-  - {fileID: 68540393}
+  - {fileID: 209957851}
   - {fileID: 2112279423}

--- a/Assets/Dev/KST_DF/Script/MonsterAudio.cs
+++ b/Assets/Dev/KST_DF/Script/MonsterAudio.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using Scripts.Manager;
+using UnityEngine;
+
+public class MonsterAudio : MonoBehaviour
+{
+    [SerializeField] private AudioClip shotSound;
+    [SerializeField] private AudioClip hurtSound;
+    [SerializeField] private AudioClip slashSound;
+    [SerializeField] private AudioClip deadSound;
+    public void ShootingSound()
+    {
+        AudioManager.Instance.PlaySFX(shotSound);
+    }
+    public void HurtSound()
+    {
+        AudioManager.Instance.PlaySFX(hurtSound);
+    }
+    public void SlashSound()
+    {
+        AudioManager.Instance.PlaySFX(slashSound);
+    }
+    public void DeadSound()
+    {
+        AudioManager.Instance.PlaySFX(deadSound);
+    }
+}

--- a/Assets/Dev/KST_DF/Script/MonsterAudio.cs.meta
+++ b/Assets/Dev/KST_DF/Script/MonsterAudio.cs.meta
@@ -1,0 +1,15 @@
+fileFormatVersion: 2
+guid: d2ef31caf2046364285cd21114743285
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences:
+  - shotSound: {fileID: 8300000, guid: 51a75955cea7541b0809fed2de82be21, type: 3}
+  - hurtSound: {fileID: 8300000, guid: 646d5e8a87d4aab4ebb8df843fd09723, type: 3}
+  - slashSound: {fileID: 8300000, guid: 178b03530acb54f18847f85200fff708, type: 3}
+  - deadSound: {fileID: 8300000, guid: 7ac0dfae083d2b94780328d7e42f29e7, type: 3}
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dev/KST_DF/Script/StraightPatternMonster.cs
+++ b/Assets/Dev/KST_DF/Script/StraightPatternMonster.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 
 public class StraightPatternMonster : MonsterBase
 {
-    //TODO<김승태>직선패턴 몬스터는 어떠한 몬스터와도 충돌이 발생하지 않도록 해야함.
     private Vector3 m_direction;
     [SerializeField]private float m_timer =10f;
 
@@ -12,6 +11,8 @@ public class StraightPatternMonster : MonsterBase
     {
         base.Start();
         m_canTrackingPlayer = false;
+        Physics.IgnoreLayerCollision(this.gameObject.layer,this.gameObject.layer,true);
+        Physics.IgnoreLayerCollision(this.gameObject.layer,LayerMask.NameToLayer("Monster"),true);
     }
     public void InitDir(Vector3 targetDir)
     {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -24,7 +24,7 @@ TagManager:
   - 
   - Monster
   - Arrow
-  - 
+  - StraightMonster
   - 
   - 
   - 


### PR DESCRIPTION
1. 직선패턴 몬스터 충돌 처리
- 직선패턴 몬스터를 레이어를 통해 충돌을 처리함. (해당 패턴 몬스터 간의 충돌 및 몬스터 간의 충돌 무시)

2. 몬스터 사운드 추가
- 몬스터 애니메이션 각 클립에 사운드(Shot, Hurt, Slash, Dead) 추가